### PR TITLE
Bug 1231792 - Enable bookmark-history-menu experiment on Nightly only…

### DIFF
--- a/experiments.json
+++ b/experiments.json
@@ -12,5 +12,10 @@
       "min": "50",
       "max": "100"
     }
+  },
+  "bookmark-history-menu": {
+    "match": {
+      "appId": "org.mozilla.fennec"
+    }
   }
 }


### PR DESCRIPTION
@milescrabill I tested this locally (with my local build app ID, `org.mozilla.fennec_leibovic`), and it didn't work as expected. Am I missing something?

Also, as a feature request, if would be nice to use the regex-like app ID pattern @mfinkle mentioned in our meeting, so that I could enable this for all `org.mozilla.fennec*` app IDs.
