### PR TITLE
Add search experiment from bug 1240549 (show search mode w/ search term)

### DIFF
--- a/experiments.json
+++ b/experiments.json
@@ -21,5 +21,12 @@
       "min": "0",
       "max": "100"
     }
+  },
+  "search-term": {
+    "match": {},
+    "buckets": {
+      "min": "0",
+      "max": "50"
+    }
   }
 }


### PR DESCRIPTION
I'm splitting this off from the other pull request, because it seems like there might be more to discuss about onboarding, but we should get this out so people start seeing the search-term changes (which are currently in aurora, but being shown to 0% of people).

This doesn't include any versions because we're currently running the experiment on everyone. If we decide to add a new experiment that conflicts with this, or we decide to turn this experiment off, we'll may need to add versions if we care about showing this to some subset of versions.

Related but not specific to this experiment: the other way we could do this is have switchboard control how many people are _not_ in the [search term] experiment. That way, if/when we decide to ship it to everyone, we can just remove this experiment from the switchboard server, and the default action will be "show this feature". Paraphrasing what ncalexander said, once we publish this, we'll have to keep it published forever because we can't guarantee that people will update to the "newest" version that has the feature turned on by default in code. (But maybe that's acceptable, and if you don't update to the latest version you don't get all the new features.)
