### PR TITLE
Bug 1004734 - Create whatsnew-notification experiment. r=liuche, Bug 1253588 - Enable bookmark history menu experiment by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Any changes to this file require the approval of a Firefox for Android peer, suc
 Experiment names are defined in the client in [Experiments.java](http://hg.mozilla.org/mozilla-central/file/tip/mobile/android/base/java/org/mozilla/gecko/util/Experiments.java).
 
 UI experiments:
-* `bookmark-history-menu`: Display History and Bookmarks in 3-dot menu
-* `search-term`: Show search mode (instead of home panels) when tapping on urlbar if there is a search term in the urlbar
+* `bookmark-history-menu`: Display "History" and "Bookmarks" menu items in 3-dot menu.
+* `search-term`: Show search mode (instead of home panels) when tapping on urlbar if there is a search term in the urlbar.
+* `whatsnew-notification`: Show a "What's new" notification when the browser updates. Tapping on this notification will open a new tab with a SUMO article about what is new in Firefox.
 
 Onboarding experiments are unique because we use local logic to determine whether a client is in an experiment. We do this because we must know if the experiment is active at startup, and we cannot wait to contact the Switchboard server. Given this fact, changes to `experiments.json` will not affect onboarding experiments. Those experiments are maintained in the client codebase.
 

--- a/experiments.json
+++ b/experiments.json
@@ -16,5 +16,13 @@
       "min": "0",
       "max": "100"
     }
+  },
+  "whatsnew-notification": {
+    "match": {
+    },
+    "buckets": {
+      "min": "0",
+      "max": "0"
+    }
   }
 }

--- a/experiments.json
+++ b/experiments.json
@@ -1,7 +1,7 @@
 {
   "bookmark-history-menu": {
     "match": {
-      "appId": "^org.mozilla.fennec$"
+      "appId": "^org.mozilla.fennec*|^org.mozilla.firefox_beta$"
     },
     "buckets": {
       "min": "0",


### PR DESCRIPTION
@liuche Can you review this?

@milescrabill I tested this locally to confirm this experiment won't be active for any users, but I'd like for you to also confirm that this is how the bucket logic works. It's not clear to me whether the min/max are inclusive or exclusive. I'm assuming that this patch means that no buckets will be active, but it's possible it could also be active for users in bucket 0, if buckets are 0-indexed. I want us to update the README to clarify this. 
