### PR TITLE
Bug 1258812 - Add experiments for content notifications. r=margaret

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ UI experiments:
 * `offline-cache`: Try to load pages from disk cache when network is offline.
 * `search-term`: Show search mode (instead of home panels) when tapping on urlbar if there is a search term in the urlbar.
 * `whatsnew-notification`: Show a "What's new" notification when the browser updates. Tapping on this notification will open a new tab with a SUMO article about what is new in Firefox.
+* `content-notifications-12hrs`: Enable content notifications and check for updates every 12 hours at random times based on app start.
+* `content-notifications-8am`: Enable content notifications and check for updates every day at 8 am.
+* `content-notifications-5pm`: Enable content notifications and check for updates every day at 5 pm.
 
 Onboarding experiments are unique because we use local logic to determine whether a client is in an experiment. We do this because we must know if the experiment is active at startup, and we cannot wait to contact the Switchboard server. Given this fact, changes to `experiments.json` will not affect onboarding experiments. Those experiments are maintained in the client codebase.
 

--- a/experiments.json
+++ b/experiments.json
@@ -33,5 +33,32 @@
       "min": "0",
       "max": "0"
     }
+  },
+  "content-notifications-12hrs": {
+    "match": {
+      "appId": "^org.mozilla.fennec$"
+    },
+    "buckets": {
+      "min": "25",
+      "max": "50"
+    }
+  },
+  "content-notifications-8am": {
+    "match": {
+      "appId": "^org.mozilla.fennec$"
+    },
+    "buckets": {
+      "min": "50",
+      "max": "75"
+    }
+  },
+  "content-notifications-5pm": {
+    "match": {
+      "appId": "^org.mozilla.fennec$"
+    },
+    "buckets": {
+      "min": "75",
+      "max": "100"
+    }
   }
 }


### PR DESCRIPTION
I'm not really sure if the ranges are inclusive or exclusive.
- 25-50 : Does this include bucket 25 and bucket 50?
- With my configuration below: Can someone be in bucket 50 and be in two content notification experiments?
- The hundred buckets are they 0-99 or 1-100?
