### PR TITLE
Bug 1253588 - Enable bookmark history menu experiment by default. r=sebastian

### DIFF
--- a/experiments.json
+++ b/experiments.json
@@ -1,7 +1,6 @@
 {
   "bookmark-history-menu": {
     "match": {
-      "appId": "^org.mozilla.fennec|^org.mozilla.firefox_beta$"
     },
     "buckets": {
       "min": "0",


### PR DESCRIPTION
@pocmo I realize that we might have been able to do this sooner using the version number matching, to avoid needing to time this to coincide with the release date.

However, we do want to enable this for 46, so we should merge this when we release the app update tomorrow.
