### PR TITLE
Bug 1271352 - Enable DLC sync for 50% of the Nightly users. r=margaret

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ UI experiments:
 * `triple-readerview-bookmark-prompt`: Show prompt to bookmark the current page if it has been reader-viewed 3 times ([bug 1247689](https://bugzilla.mozilla.org/show_bug.cgi?id=1247689))
 * `urlbar-show-origin-only`: Only show origin in URL bar instead of full URL ([bug 1236431](https://bugzilla.mozilla.org/show_bug.cgi?id=1236431))
 * `urlbar-show-ev-cert-owner`: Show name of organization (EV cert) instead of full URL in URL bar ([bug 1249594](https://bugzilla.mozilla.org/show_bug.cgi?id=1249594))
+* `download-content-catalog-sync`: Synchronize catalog of downloadable content from Kinto (Staged rollout - [bug 1271352](https://bugzilla.mozilla.org/show_bug.cgi?id=1271352))
 
 Onboarding experiments are unique because we use local logic to determine whether a client is in an experiment. We do this because we must know if the experiment is active at startup, and we cannot wait to contact the Switchboard server. Given this fact, changes to `experiments.json` will not affect onboarding experiments. Those experiments are maintained in the client codebase.
 

--- a/experiments.json
+++ b/experiments.json
@@ -100,5 +100,14 @@
       "min": "0",
       "max": "100"
     }
+  },
+  "download-content-catalog-sync": {
+    "match": {
+      "appId": "^org.mozilla.fennec$"
+    },
+    "buckets": {
+      "min": "0",
+      "max": "50"
+    }
   }
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1271352
