### PR TITLE
Disable searchterm

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Here is a list of keys that are currently supported:
 
 The `buckets` key is a JSON object that contains two keys, `min` and `max`.
 `min` and `max` should be strings containing integer values, `0 <= x <= 100`
-(switchboard is currently configured to have 100 buckets).
+The bounds are [low, high). Switchboard is currently configured to have 100 buckets (0-99), and because the high is a non-inclusive upper bound experiments should use 100 as the high value. There is no check for out of bounds values, so "disabled" experiments can have low/high buckets keys that are either out of bounds or have low == high.
 
 ## Making Client Changes
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,21 @@ Here is a list of keys that are currently supported:
 ### `buckets` Key
 
 The `buckets` key is a JSON object that contains two keys, `min` and `max`.
-`min` and `max` should be strings containing integer values, `0 <= x <= 100`
-The bounds are [low, high). Switchboard is currently configured to have 100 buckets (0-99), and because the high is a non-inclusive upper bound experiments should use 100 as the high value. There is no check for out of bounds values, so "disabled" experiments can have low/high buckets keys that are either out of bounds or have low == high.
+`min` and `max` should be strings containing integer values, `0 <= min <= max <= 100`. The bounds are [min, max).
+
+The experiment "experiment-name" below will trigger for buckets 0-49:
+
+```
+"experiment-name": {
+  "match": {},
+  "buckets": {
+    "min": "0",
+    "max": "50"
+  }
+}
+```
+
+Switchboard is currently configured to have 100 buckets (0-99), but the max value is a non-inclusive upper bound, meaning that unless a value of 100 or higher is used as the max, bucket 99 will not be included. There is no check for out of bounds values, so "disabled" experiments can have min/max buckets keys that are either out of bounds or have min == max.
 
 ## Making Client Changes
 

--- a/README.md
+++ b/README.md
@@ -60,9 +60,13 @@ Each key/value pair is a regular expression match requirement for that experimen
 Regular expressions are matched by the node backend, and follow [this](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) format. Note: this means that if you want an **exact** string match, as opposed to a RegExp that will match strings that **contain** your specified string, you must use string delimiters (^ and $ for start and end of string respectively).
 All key/value pairs **must** be satisfied for the experiment to be considered a match.
 
-Here is a list of keys that are currently supported:
+Supported keys are specified by the client, as parameters on the [server request(http://hg.mozilla.org/mozilla-central/file/494289c72ba3/mobile/android/thirdparty/com/keepsafe/switchboard/SwitchBoard.java#l226). Here is a list of keys that are currently supported in Firefox for Android:
 * `appId`: The Android app ID (e.g. `org.mozilla.fennec`, `org.mozilla.firefox_beta`, `org.mozilla.firefox`)
-* ...
+* `version`: The Firefox app version number (e.g. `47.0a1'`, `46.0`)
+* `lang`: Language, pulled from the default locale (e.g. `eng`)
+* `country`: Country, pulled from the default locale (e.g. `USA`)
+* `device`: Android device name
+* `manufacturer`: Android device manufacturer
 
 ### `buckets` Key
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Each key/value pair is a regular expression match requirement for that experimen
 Regular expressions are matched by the node backend, and follow [this](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) format. Note: this means that if you want an **exact** string match, as opposed to a RegExp that will match strings that **contain** your specified string, you must use string delimiters (^ and $ for start and end of string respectively).
 All key/value pairs **must** be satisfied for the experiment to be considered a match.
 
-Supported keys are specified by the client, as parameters on the [server request(http://hg.mozilla.org/mozilla-central/file/494289c72ba3/mobile/android/thirdparty/com/keepsafe/switchboard/SwitchBoard.java#l226). Here is a list of keys that are currently supported in Firefox for Android:
+Supported keys are specified by the client, as parameters on the [server request](http://hg.mozilla.org/mozilla-central/file/494289c72ba3/mobile/android/thirdparty/com/keepsafe/switchboard/SwitchBoard.java#l226). Here is a list of keys that are currently supported in Firefox for Android:
 * `appId`: The Android app ID (e.g. `org.mozilla.fennec`, `org.mozilla.firefox_beta`, `org.mozilla.firefox`)
 * `version`: The Firefox app version number (e.g. `47.0a1'`, `46.0`)
 * `lang`: Language, pulled from the default locale (e.g. `eng`)

--- a/experiments.json
+++ b/experiments.json
@@ -16,15 +16,6 @@
       "max": "100"
     }
   },
-  "search-term": {
-    "match": {
-      "appId": "^org.mozilla.fennec|^org.mozilla.firefox_beta$"
-    },
-    "buckets": {
-      "min": "0",
-      "max": "100"
-    }
-  },
   "whatsnew-notification": {
     "match": {
     },

--- a/experiments.json
+++ b/experiments.json
@@ -1,7 +1,6 @@
 {
   "bookmark-history-menu": {
     "match": {
-      "appId": "^org.mozilla.fennec|^org.mozilla.firefox_beta$"
     },
     "buckets": {
       "min": "0",


### PR DESCRIPTION
Removing switchboard component from bug  1275782. It doesn't matter which order these land in, if this gets merged first the isInExperiment will return, and if that lands first, we won't be checking for this switchboard experiment at all.
