### PR TITLE
Bug 1275782 - Disable "search-term" experiment. r=margaret

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ UI experiments:
 * `bookmark-history-menu`: Display "History" and "Bookmarks" menu items in 3-dot menu.
 * `malware-download-protection`: Enable malware download protection.
 * `offline-cache`: Try to load pages from disk cache when network is offline.
-* `search-term`: Show search mode (instead of home panels) when tapping on urlbar if there is a search term in the urlbar.
 * `whatsnew-notification`: Show a "What's new" notification when the browser updates. Tapping on this notification will open a new tab with a SUMO article about what is new in Firefox.
 * `content-notifications-12hrs`: Enable content notifications and check for updates every 12 hours at random times based on app start.
 * `content-notifications-8am`: Enable content notifications and check for updates every day at 8 am.

--- a/experiments.json
+++ b/experiments.json
@@ -16,15 +16,6 @@
       "max": "100"
     }
   },
-  "search-term": {
-    "match": {
-      "appId": "^org.mozilla.fennec|^org.mozilla.firefox_beta$"
-    },
-    "buckets": {
-      "min": "0",
-      "max": "100"
-    }
-  },
   "whatsnew-notification": {
     "match": {
     },


### PR DESCRIPTION
Removing switchboard component from bug 1275782. It doesn't matter which order these land in, if this gets merged first the isInExperiment will return, and if that lands first, we won't be checking for this switchboard experiment at all.

This is based on stage, rather than master.
