### PR TITLE
Bug 1277180 - Enable "Add to home screen" experiment in Beta. r=margaret

### DIFF
--- a/experiments.json
+++ b/experiments.json
@@ -59,7 +59,7 @@
   },
   "promote-add-to-homescreen": {
     "match": {
-      "appId": "^org.mozilla.fennec"
+      "appId": "^org.mozilla.fennec|^org.mozilla.firefox_beta$"
     },
     "buckets": {
       "min": 50,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1277180
